### PR TITLE
Refresh template using EEA template API

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutManager.java
+++ b/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutManager.java
@@ -1,0 +1,228 @@
+package org.fao.geonet.api.eealayoutapi;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Properties;
+
+import org.fao.geonet.api.API;
+import org.fao.geonet.utils.Log;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class EEALayoutManager {
+
+    private static String HEAD;
+    private static String SCRIPTS;
+    private static String HEADER;
+    private static String FOOTER;
+
+    public synchronized static void forceContentReload() throws Exception {
+        Log.info(API.LOG_MODULE_NAME, "Updating EEA template layout from remote...");
+
+        String tempHEAD = loadHeadFromAPI();
+        String tempSCRIPTS = loadScriptFromAPI();
+        String tempHEADER = loadHeaderFormEEAapi();
+        String tempFOOTER = loadFooterFormEEAapi();
+
+        HEAD = tempHEAD;
+        SCRIPTS = tempSCRIPTS;
+        HEADER = tempHEADER;
+        FOOTER = tempFOOTER;
+
+    }
+
+    public static String getHEAD() {
+        if (HEAD == null) {
+            try {
+                Log.info(API.LOG_MODULE_NAME, "Updating EEA head layout from remote...");
+                HEAD = loadHeadFromAPI();
+            } catch (Exception e) {
+                Log.error(API.LOG_MODULE_NAME, "Error in updating EEA head from remote API", e);
+                return "";
+            }
+        }
+
+        return HEAD;
+    }
+
+    public static String getSCRIPTS() {
+        if (SCRIPTS == null) {
+            try {
+                Log.info(API.LOG_MODULE_NAME, "Updating EEA scripts layout from remote...");
+                SCRIPTS = loadScriptFromAPI();
+            } catch (Exception e) {
+                Log.error(API.LOG_MODULE_NAME, "Error in updating EEA scripts from remote API", e);
+                return "";
+            }
+        }
+
+        return SCRIPTS;
+    }
+
+    public static String getHEADER() {
+        if (HEADER == null) {
+            try {
+                Log.info(API.LOG_MODULE_NAME, "Updating EEA header layout from remote...");
+                HEADER = loadHeaderFormEEAapi();
+            } catch (Exception e) {
+                Log.error(API.LOG_MODULE_NAME, "Error in updating EEA header from remote API", e);
+                return "";
+            }
+        }
+
+        return HEADER;
+    }
+
+    public static String getFOOTER() {
+        if (FOOTER == null) {
+            try {
+                Log.info(API.LOG_MODULE_NAME, "Updating EEA footer layout from remote...");
+                FOOTER = loadFooterFormEEAapi();
+            } catch (Exception e) {
+                Log.error(API.LOG_MODULE_NAME, "Error in updating EEA footer from remote API", e);
+                return "";
+            }
+        }
+
+        return FOOTER;
+    }
+
+    private static String loadHeadFromAPI() throws Exception {
+        URL url;
+        InputStream is = null;
+        BufferedReader inputReader = null;
+        try {
+            url = new URL(readProperty("eea.api.template.head"));
+            is = url.openStream(); // throws an IOException
+            inputReader = new BufferedReader(new InputStreamReader(is));
+
+            StringBuilder sb = new StringBuilder();
+            String inline;
+
+            sb.append("<head>");
+            while ((inline = inputReader.readLine()) != null) {
+
+                sb.append(inline);
+            }
+            sb.append("<script src=\"../../srv/api/eealayoutupdate/script\" /></head>");
+
+            Document doc = Jsoup.parse(sb.toString());
+
+            Elements script = doc.select("script");
+            for (Element element : script) {
+                element.html("");
+
+            }
+
+            return doc.head().html();
+
+        } finally {
+            try {
+                if (is != null) {
+                    is.close();
+                }
+                if (inputReader != null) {
+                    inputReader.close();
+                }
+            } catch (IOException ioe) {
+            }
+        }
+    }
+
+    private static String loadScriptFromAPI() throws Exception {
+        URL url;
+        InputStream is = null;
+        BufferedReader inputReader = null;
+        try {
+            url = new URL(readProperty("eea.api.template.head"));
+            is = url.openStream(); // throws an IOException
+            inputReader = new BufferedReader(new InputStreamReader(is));
+
+            StringBuilder sb = new StringBuilder();
+            String inline;
+
+            sb.append("<head>");
+            while ((inline = inputReader.readLine()) != null) {
+
+                sb.append(inline);
+            }
+            sb.append("</head>");
+
+            Document doc = Jsoup.parse(sb.toString());
+
+            StringBuffer javascript = new StringBuffer();
+
+            Elements script = doc.select("script");
+            for (Element element : script) {
+                javascript.append(element.data());
+
+            }
+
+            return javascript.toString();
+
+        } finally {
+            try {
+                if (is != null) {
+                    is.close();
+                }
+                if (inputReader != null) {
+                    inputReader.close();
+                }
+            } catch (IOException ioe) {
+            }
+        }
+    }
+
+    private static String loadHeaderFormEEAapi() throws Exception {
+        return loadPageSectionFormEEAapi(readProperty("eea.api.template.header"));
+    }
+
+    private static String loadFooterFormEEAapi() throws Exception {
+        return loadPageSectionFormEEAapi(readProperty("eea.api.template.footer"));
+    }
+
+    private static String loadPageSectionFormEEAapi(String stringUrl) throws Exception {
+        URL url;
+        InputStream is = null;
+        BufferedReader inputReader = null;
+        try {
+            url = new URL(stringUrl);
+            is = url.openStream(); // throws an IOException
+            inputReader = new BufferedReader(new InputStreamReader(is));
+            StringBuilder sb = new StringBuilder();
+            String inline = "";
+
+            while ((inline = inputReader.readLine()) != null) {
+
+                sb.append(inline);
+            }
+
+            return sb.toString();
+
+        } finally {
+            try {
+                if (is != null) {
+                    is.close();
+                }
+                if (inputReader != null) {
+                    inputReader.close();
+                }
+            } catch (IOException ioe) {
+            }
+        }
+    }
+
+    private static String readProperty(String property) throws IOException {
+        Properties prop = new Properties();
+        // load a properties file from class path, inside static method
+        prop.load(EEALayoutManager.class.getClassLoader().getResourceAsStream("eeaAPI.properties"));
+        return prop.getProperty(property);
+
+    }
+
+}

--- a/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutManager.java
+++ b/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutManager.java
@@ -109,7 +109,6 @@ public class EEALayoutManager {
 
                 sb.append(inline);
             }
-            sb.append("<script src=\"../../srv/api/eealayoutupdate/script\" /></head>");
 
             Document doc = Jsoup.parse(sb.toString());
 

--- a/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutUpdateAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutUpdateAPI.java
@@ -60,7 +60,7 @@ public class EEALayoutUpdateAPI {
     }
 
     @ApiOperation(value = "Get EEA <head> content", nickname = "getHead")
-    @RequestMapping(value = "/eealayoutupdate/head", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @RequestMapping(value = "/eealayoutupdate/head", produces = MediaType.APPLICATION_XHTML_XML_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasRole('Administrator')")
     @ResponseBody
@@ -70,7 +70,7 @@ public class EEALayoutUpdateAPI {
     }
 
     @ApiOperation(value = "Get EEA embedded scripts", nickname = "getScript")
-    @RequestMapping(value = "/eealayoutupdate/script", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @RequestMapping(value = "/eealayoutupdate/script", produces = MediaType.APPLICATION_XHTML_XML_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody
     public String getScript(@ApiIgnore
@@ -80,7 +80,7 @@ public class EEALayoutUpdateAPI {
     }
 
     @ApiOperation(value = "Get EEA footer html", nickname = "getFooter")
-    @RequestMapping(value = "/eealayoutupdate/footer", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @RequestMapping(value = "/eealayoutupdate/footer", produces = MediaType.APPLICATION_XHTML_XML_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasRole('Administrator')")
     @ResponseBody
@@ -90,7 +90,7 @@ public class EEALayoutUpdateAPI {
     }
 
     @ApiOperation(value = "Get EEA header html content", nickname = "getHeader")
-    @RequestMapping(value = "/eealayoutupdate/header", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @RequestMapping(value = "/eealayoutupdate/header", produces = MediaType.APPLICATION_XHTML_XML_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasRole('Administrator')")
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutUpdateAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutUpdateAPI.java
@@ -45,10 +45,9 @@ import springfox.documentation.annotations.ApiIgnore;
 @Controller("eealayoutupdate")
 public class EEALayoutUpdateAPI {
 
-    @ApiOperation(value = "Refresh EEA Template from API", nickname = "refreshTemplate")
-    @RequestMapping(value = "/eealayoutupdate/refreshTemplate", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @ApiOperation(value = "Refresh EEA Template from API", nickname = "refreshtemplate")
+    @RequestMapping(value = "/eealayoutupdate/refreshtemplate", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
-    @PreAuthorize("hasRole('Administrator')")
     @ResponseBody
     public void refreshTemplate(@ApiIgnore
     final HttpServletResponse response) {

--- a/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutUpdateAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/eealayoutapi/EEALayoutUpdateAPI.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.eealayoutapi;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.fao.geonet.api.API;
+import org.fao.geonet.utils.Log;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import springfox.documentation.annotations.ApiIgnore;
+
+@RequestMapping(value = { "/api", "/api/" + API.VERSION_0_1 })
+@Api(value = "eealayoutupdate", tags = "eealayoutupdate", description = "EEA Layout Update API")
+@Controller("eealayoutupdate")
+public class EEALayoutUpdateAPI {
+
+    @ApiOperation(value = "Refresh EEA Template from API", nickname = "refreshTemplate")
+    @RequestMapping(value = "/eealayoutupdate/refreshTemplate", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("hasRole('Administrator')")
+    @ResponseBody
+    public void refreshTemplate(@ApiIgnore
+    final HttpServletResponse response) {
+        try {
+            EEALayoutManager.forceContentReload();
+        } catch (Exception e) {
+            Log.error(API.LOG_MODULE_NAME, "Error in updating EEA layout from remote API", e);
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        }
+    }
+
+    @ApiOperation(value = "Get EEA <head> content", nickname = "getHead")
+    @RequestMapping(value = "/eealayoutupdate/head", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("hasRole('Administrator')")
+    @ResponseBody
+    public String getHead(@ApiIgnore
+    final HttpServletResponse response) {
+        return EEALayoutManager.getHEAD();
+    }
+
+    @ApiOperation(value = "Get EEA embedded scripts", nickname = "getScript")
+    @RequestMapping(value = "/eealayoutupdate/script", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @ResponseStatus(value = HttpStatus.OK)
+    @ResponseBody
+    public String getScript(@ApiIgnore
+    final HttpServletResponse response) {
+
+        return EEALayoutManager.getSCRIPTS();
+    }
+
+    @ApiOperation(value = "Get EEA footer html", nickname = "getFooter")
+    @RequestMapping(value = "/eealayoutupdate/footer", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("hasRole('Administrator')")
+    @ResponseBody
+    public String getFooter(@ApiIgnore
+    final HttpServletResponse response) {
+        return EEALayoutManager.getFOOTER();
+    }
+
+    @ApiOperation(value = "Get EEA header html content", nickname = "getHeader")
+    @RequestMapping(value = "/eealayoutupdate/header", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @ResponseStatus(value = HttpStatus.OK)
+    @PreAuthorize("hasRole('Administrator')")
+    @ResponseBody
+    public String getHeader(@ApiIgnore
+    final HttpServletResponse response) {
+        return EEALayoutManager.getHEADER();
+    }
+
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -32,6 +32,32 @@
 
 }
 
+// header
+#cross-site-top {
+  // hide sidepanels
+  #tip-externalsites-networks, #js-siteaction-panels {
+    display: none;
+  }
+  a:visited, a:link, a {
+    color: #fff !important;
+  }
+}
+
+// change GN layout
+.gn-top-bar {
+  margin-top: 167px;
+}
+[ng-app ="gn_editor"] {
+  body {
+    .gn-top-bar {
+      margin-top: 0;
+    }
+  }
+}
+.gn-editor-board, [data-ng-controller="GnAdminController"] {
+  background-color: #fff !important;
+}
+
 /* Override Bootstrap style */
 
 .btn-default {

--- a/web/src/main/webResources/WEB-INF/classes/eeaAPI.properties
+++ b/web/src/main/webResources/WEB-INF/classes/eeaAPI.properties
@@ -1,0 +1,6 @@
+# URL OF EEA API TO GET THE HEAD
+eea.api.template.head=https://www.eea.europa.eu/templates/v2/getRequiredHead
+# URL OF EEA API TO GET THE HEADER
+eea.api.template.header=https://www.eea.europa.eu/templates/v2/getHeader
+# URL OF EEA API TO GET THE FOOTER
+eea.api.template.footer=https://www.eea.europa.eu/templates/v2/getFooter

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql-eea/db-migrate-201808.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql-eea/db-migrate-201808.sql
@@ -1,0 +1,5 @@
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES
+  ('system/eea/templateapi', 'true', 2, 9990, 'y');
+
+UPDATE Settings SET value='3.4.3' WHERE name='system/platform/version';
+

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -37,6 +37,7 @@
   <xsl:include href="base-layout-cssjs-loader.xsl"/>
   <xsl:include href="skin/default/skin.xsl"/>
 
+  <xsl:include href="eea-layout.xsl"/>
   <xsl:include href="eea-layout-api.xsl"/>
 
   <xsl:template match="/">
@@ -54,7 +55,14 @@
         <meta name="keywords" content=""/>
 
 
-        <xsl:call-template name="eea-head"/>
+        <xsl:choose>
+          <xsl:when test="$requestParameters/noeeaapi">
+            <xsl:call-template name="eea-head"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="eea-head-api"/>
+          </xsl:otherwise>
+        </xsl:choose>
 
         <!--<link rel="icon" sizes="16x16 32x32 48x48" type="image/png" href="../../images/logos/favicon.png"/>-->
         <link href="rss.search?sortBy=changeDate" rel="alternate" type="application/rss+xml"
@@ -72,7 +80,14 @@
       -->
       <body data-ng-controller="GnCatController">
 
-        <xsl:call-template name="eea-header"/>
+        <xsl:choose>
+          <xsl:when test="$requestParameters/noeeaapi">
+            <xsl:call-template name="eea-header"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="eea-header-api"/>
+          </xsl:otherwise>
+        </xsl:choose>
 
         <div data-gn-alert-manager=""></div>
 
@@ -104,7 +119,14 @@
         </xsl:choose>
 
 
-        <xsl:call-template name="eea-footer"/>
+        <xsl:choose>
+          <xsl:when test="$requestParameters/noeeaapi">
+            <xsl:call-template name="eea-footer"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="eea-footer-api"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </body>
     </html>
   </xsl:template>

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -60,6 +60,8 @@
           </xsl:when>
           <xsl:otherwise>
             <xsl:call-template name="eea-head-api"/>
+            <xsl:call-template name="eea-script-api"/>
+
           </xsl:otherwise>
         </xsl:choose>
 

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -37,7 +37,7 @@
   <xsl:include href="base-layout-cssjs-loader.xsl"/>
   <xsl:include href="skin/default/skin.xsl"/>
 
-  <xsl:include href="eea-layout.xsl"/>
+  <xsl:include href="eea-layout-api.xsl"/>
 
   <xsl:template match="/">
     <html ng-app="{$angularModule}" lang="{$lang}" id="ng-app">

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -54,9 +54,8 @@
         <meta name="description" content=""/>
         <meta name="keywords" content=""/>
 
-
         <xsl:choose>
-          <xsl:when test="$requestParameters/noeeaapi">
+          <xsl:when test="$requestParameters/noeeaapi or $env/system/eea/templateapi = 'false'">
             <xsl:call-template name="eea-head"/>
           </xsl:when>
           <xsl:otherwise>
@@ -81,7 +80,7 @@
       <body data-ng-controller="GnCatController">
 
         <xsl:choose>
-          <xsl:when test="$requestParameters/noeeaapi">
+          <xsl:when test="$requestParameters/noeeaapi or $env/system/eea/templateapi = 'false'">
             <xsl:call-template name="eea-header"/>
           </xsl:when>
           <xsl:otherwise>
@@ -120,7 +119,7 @@
 
 
         <xsl:choose>
-          <xsl:when test="$requestParameters/noeeaapi">
+          <xsl:when test="$requestParameters/noeeaapi or $env/system/eea/templateapi = 'false'">
             <xsl:call-template name="eea-footer"/>
           </xsl:when>
           <xsl:otherwise>

--- a/web/src/main/webapp/xslt/eea-layout-api.xsl
+++ b/web/src/main/webapp/xslt/eea-layout-api.xsl
@@ -290,4 +290,16 @@
     <!-- EEA HEADER END -->
   </xsl:template>
 
+  <xsl:template name="eea-script-api">
+    <!-- EEA HEADER START -->
+    <xsl:variable name="s">
+      <xsl:copy-of select="java:getSCRIPTS()" />
+    </xsl:variable>
+    <script type="text/javascript">
+      <xsl:value-of disable-output-escaping="yes"
+        select="$s" />
+    </script>
+    <!-- EEA HEADER END -->
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/eea-layout-api.xsl
+++ b/web/src/main/webapp/xslt/eea-layout-api.xsl
@@ -1,25 +1,293 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE document [ 
-<!ENTITY mdash  "&#8212;">
-<!ENTITY  head SYSTEM "http://www.eea.europa.eu/templates/v2/getRequiredHead?jsdisable=all"> 
-<!ENTITY  footer SYSTEM 'http://www.eea.europa.eu/templates/v2/getFooter'> 
-<!ENTITY  header SYSTEM 'http://www.eea.europa.eu/templates/v2/getHeader'> 
+<!ENTITY nbsp    "&#160;" >
+<!ENTITY iexcl   "&#161;" >
+<!ENTITY cent    "&#162;" >
+<!ENTITY pound   "&#163;" >
+<!ENTITY curren  "&#164;" >
+<!ENTITY yen     "&#165;" >
+<!ENTITY brvbar  "&#166;" >
+<!ENTITY sect    "&#167;" >
+<!ENTITY uml     "&#168;" >
+<!ENTITY copy    "&#169;" >
+<!ENTITY ordf    "&#170;" >
+<!ENTITY laquo   "&#171;" >
+<!ENTITY not     "&#172;" >
+<!ENTITY shy     "&#173;" >
+<!ENTITY reg     "&#174;" >
+<!ENTITY macr    "&#175;" >
+<!ENTITY deg     "&#176;" >
+<!ENTITY plusmn  "&#177;" >
+<!ENTITY sup2    "&#178;" >
+<!ENTITY sup3    "&#179;" >
+<!ENTITY acute   "&#180;" >
+<!ENTITY micro   "&#181;" >
+<!ENTITY para    "&#182;" >
+<!ENTITY middot  "&#183;" >
+<!ENTITY cedil   "&#184;" >
+<!ENTITY sup1    "&#185;" >
+<!ENTITY ordm    "&#186;" >
+<!ENTITY raquo   "&#187;" >
+<!ENTITY frac14  "&#188;" >
+<!ENTITY frac12  "&#189;" >
+<!ENTITY frac34  "&#190;" >
+<!ENTITY iquest  "&#191;" >
+<!ENTITY Agrave  "&#192;" >
+<!ENTITY Aacute  "&#193;" >
+<!ENTITY Acirc   "&#194;" >
+<!ENTITY Atilde  "&#195;" >
+<!ENTITY Auml    "&#196;" >
+<!ENTITY Aring   "&#197;" >
+<!ENTITY AElig   "&#198;" >
+<!ENTITY Ccedil  "&#199;" >
+<!ENTITY Egrave  "&#200;" >
+<!ENTITY Eacute  "&#201;" >
+<!ENTITY Ecirc   "&#202;" >
+<!ENTITY Euml    "&#203;" >
+<!ENTITY Igrave  "&#204;" >
+<!ENTITY Iacute  "&#205;" >
+<!ENTITY Icirc   "&#206;" >
+<!ENTITY Iuml    "&#207;" >
+<!ENTITY ETH     "&#208;" >
+<!ENTITY Ntilde  "&#209;" >
+<!ENTITY Ograve  "&#210;" >
+<!ENTITY Oacute  "&#211;" >
+<!ENTITY Ocirc   "&#212;" >
+<!ENTITY Otilde  "&#213;" >
+<!ENTITY Ouml    "&#214;" >
+<!ENTITY times   "&#215;" >
+<!ENTITY Oslash  "&#216;" >
+<!ENTITY Ugrave  "&#217;" >
+<!ENTITY Uacute  "&#218;" >
+<!ENTITY Ucirc   "&#219;" >
+<!ENTITY Uuml    "&#220;" >
+<!ENTITY Yacute  "&#221;" >
+<!ENTITY THORN   "&#222;" >
+<!ENTITY szlig   "&#223;" >
+<!ENTITY agrave  "&#224;" >
+<!ENTITY aacute  "&#225;" >
+<!ENTITY acirc   "&#226;" >
+<!ENTITY atilde  "&#227;" >
+<!ENTITY auml    "&#228;" >
+<!ENTITY aring   "&#229;" >
+<!ENTITY aelig   "&#230;" >
+<!ENTITY ccedil  "&#231;" >
+<!ENTITY egrave  "&#232;" >
+<!ENTITY eacute  "&#233;" >
+<!ENTITY ecirc   "&#234;" >
+<!ENTITY euml    "&#235;" >
+<!ENTITY igrave  "&#236;" >
+<!ENTITY iacute  "&#237;" >
+<!ENTITY icirc   "&#238;" >
+<!ENTITY iuml    "&#239;" >
+<!ENTITY eth     "&#240;" >
+<!ENTITY ntilde  "&#241;" >
+<!ENTITY ograve  "&#242;" >
+<!ENTITY oacute  "&#243;" >
+<!ENTITY ocirc   "&#244;" >
+<!ENTITY otilde  "&#245;" >
+<!ENTITY ouml    "&#246;" >
+<!ENTITY divide  "&#247;" >
+<!ENTITY oslash  "&#248;" >
+<!ENTITY ugrave  "&#249;" >
+<!ENTITY uacute  "&#250;" >
+<!ENTITY ucirc   "&#251;" >
+<!ENTITY uuml    "&#252;" >
+<!ENTITY yacute  "&#253;" >
+<!ENTITY thorn   "&#254;" >
+<!ENTITY yuml    "&#255;" >
+<!ENTITY fnof    "&#192;" >
+<!ENTITY Alpha   "&#913;" >
+<!ENTITY Beta    "&#914;" >
+<!ENTITY Gamma   "&#915;" >
+<!ENTITY Delta   "&#916;" >
+<!ENTITY Epsilon "&#917;" >
+<!ENTITY epsilon "&#917;" >
+<!ENTITY Zeta    "&#918;" >
+<!ENTITY Eta     "&#919;" >
+<!ENTITY Theta   "&#920;" >
+<!ENTITY Iota    "&#921;" >
+<!ENTITY Kappa   "&#922;" >
+<!ENTITY Lambda  "&#923;" >
+<!ENTITY Mu      "&#924;" >
+<!ENTITY Nu      "&#925;" >
+<!ENTITY Xi      "&#926;" >
+<!ENTITY Omicron "&#927;" >
+<!ENTITY Pi      "&#928;" >
+<!ENTITY Rho     "&#929;" >
+<!ENTITY Sigma   "&#931;" >
+<!ENTITY Tau     "&#932;" >
+<!ENTITY Upsi    "&#933;" >
+<!ENTITY Phi     "&#934;" >
+<!ENTITY Chi     "&#935;" >
+<!ENTITY Psi     "&#936;" >
+<!ENTITY Omega   "&#937;" >
+<!ENTITY alpha   "&#945;" >
+<!ENTITY beta    "&#946;" >
+<!ENTITY gamma   "&#947;" >
+<!ENTITY delta   "&#948;" >
+<!ENTITY epsi    "&#949;" >
+<!ENTITY zeta    "&#950;" >
+<!ENTITY eta     "&#951;" >
+<!ENTITY theta   "&#952;" >
+<!ENTITY iota    "&#953;" >
+<!ENTITY kappa   "&#954;" >
+<!ENTITY lambda  "&#955;" >
+<!ENTITY mu      "&#956;" >
+<!ENTITY nu      "&#957;" >
+<!ENTITY xi      "&#958;" >
+<!ENTITY omicron "&#959;" >
+<!ENTITY pi      "&#960;" >
+<!ENTITY rho     "&#961;" >
+<!ENTITY sigmaf  "&#962;" >
+<!ENTITY sigma   "&#963;" >
+<!ENTITY tau     "&#964;" >
+<!ENTITY upsi    "&#965;" >
+<!ENTITY phi     "&#966;" >
+<!ENTITY chi     "&#967;" >
+<!ENTITY psi     "&#968;" >
+<!ENTITY omega   "&#969;" >
+<!ENTITY theta   "&#977;" >
+<!ENTITY upsih   "&#978;" >
+<!ENTITY piv     "&#982;" >
+<!ENTITY bull    "&#8226;" >
+<!ENTITY hellip  "&#8230;" >
+<!ENTITY prime   "&#8242;" >
+<!ENTITY Prime   "&#8243;" >
+<!ENTITY oline   "&#8254;" >
+<!ENTITY frasl   "&#8260;" >
+<!ENTITY weierp  "&#8472;" >
+<!ENTITY image   "&#8465;" >
+<!ENTITY real    "&#8476;" >
+<!ENTITY trade   "&#8482;" >
+<!ENTITY alefsym "&#8501;" >
+<!ENTITY larr    "&#8592;" >
+<!ENTITY uarr    "&#8593;" >
+<!ENTITY rarr    "&#8594;" >
+<!ENTITY darr    "&#8595;" >
+<!ENTITY harr    "&#8596;" >
+<!ENTITY crarr   "&#8629;" >
+<!ENTITY lArr    "&#8656;" >
+<!ENTITY uArr    "&#8657;" >
+<!ENTITY rArr    "&#8658;" >
+<!ENTITY dArr    "&#8659;" >
+<!ENTITY hArr    "&#8660;" >
+<!ENTITY forall  "&#8704;" >
+<!ENTITY part    "&#8706;" >
+<!ENTITY exist   "&#8707;" >
+<!ENTITY empty   "&#8709;" >
+<!ENTITY nabla   "&#8711;" >
+<!ENTITY isin    "&#8712;" >
+<!ENTITY notin   "&#8713;" >
+<!ENTITY ni      "&#8715;" >
+<!ENTITY prod    "&#8719;" >
+<!ENTITY sum     "&#8722;" >
+<!ENTITY minus   "&#8722;" >
+<!ENTITY lowast  "&#8727;" >
+<!ENTITY radic   "&#8730;" >
+<!ENTITY prop    "&#8733;" >
+<!ENTITY infin   "&#8734;" >
+<!ENTITY ang     "&#8736;" >
+<!ENTITY and     "&#8869;" >
+<!ENTITY or      "&#8870;" >
+<!ENTITY cap     "&#8745;" >
+<!ENTITY cup     "&#8746;" >
+<!ENTITY int     "&#8747;" >
+<!ENTITY there4  "&#8756;" >
+<!ENTITY sim     "&#8764;" >
+<!ENTITY cong    "&#8773;" >
+<!ENTITY asymp   "&#8773;" >
+<!ENTITY ne      "&#8800;" >
+<!ENTITY equiv   "&#8801;" >
+<!ENTITY le      "&#8804;" >
+<!ENTITY ge      "&#8805;" >
+<!ENTITY sub     "&#8834;" >
+<!ENTITY sup     "&#8835;" >
+<!ENTITY nsub    "&#8836;" >
+<!ENTITY sube    "&#8838;" >
+<!ENTITY supe    "&#8839;" >
+<!ENTITY oplus   "&#8853;" >
+<!ENTITY otimes  "&#8855;" >
+<!ENTITY perp    "&#8869;" >
+<!ENTITY sdot    "&#8901;" >
+<!ENTITY lceil   "&#8968;" >
+<!ENTITY rceil   "&#8969;" >
+<!ENTITY lfloor  "&#8970;" >
+<!ENTITY rfloor  "&#8971;" >
+<!ENTITY lang    "&#9001;" >
+<!ENTITY loz     "&#9674;" >
+<!ENTITY spades  "&#9824;" >
+<!ENTITY clubs   "&#9827;" >
+<!ENTITY hearts  "&#9829;" >
+<!ENTITY diams   "&#9830;" >
+<!ENTITY quot    "&#34;" >
+<!ENTITY amp     "&#38;" >
+<!ENTITY lt      "&#60;" >
+<!ENTITY gt      "&#62;" >
+<!ENTITY OElig   "&#338;" >
+<!ENTITY oelig   "&#339;" >
+<!ENTITY Scaron  "&#352;" >
+<!ENTITY scaron  "&#353;" >
+<!ENTITY Yuml    "&#376;" >
+<!ENTITY circ    "&#710;" >
+<!ENTITY tilde   "&#732;" >
+<!ENTITY ensp    "&#8194;" >
+<!ENTITY emsp    "&#8195;" >
+<!ENTITY thinsp  "&#8201;" >
+<!ENTITY zwnj    "&#8204;" >
+<!ENTITY zwj     "&#8205;" >
+<!ENTITY lrm     "&#8206;" >
+<!ENTITY rlm     "&#8207;" >
+<!ENTITY ndash   "&#8211;" >
+<!ENTITY mdash   "&#8212;" >
+<!ENTITY lsquo   "&#8216;" >
+<!ENTITY rsquo   "&#8217;" >
+<!ENTITY sbquo   "&#8218;" >
+<!ENTITY ldquo   "&#8220;" >
+<!ENTITY rdquo   "&#8221;" >
+<!ENTITY bdquo   "&#8222;" >
+<!ENTITY dagger  "&#8224;" >
+<!ENTITY Dagger  "&#8225;" >
+<!ENTITY permil  "&#8240;" >
+<!ENTITY lsaquo  "&#8249;" >
+<!ENTITY rsaquo  "&#8250;" >
 ]>
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:exslt="http://exslt.org/common"
-    exclude-result-prefixes="#all">
+<xsl:stylesheet version="2.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:exslt="http://exslt.org/common"
+  xmlns:java="java:org.fao.geonet.api.eealayoutapi.EEALayoutManager"
+  exclude-result-prefixes="#all">
   
+  <xsl:param name="java" />
+
   <xsl:template name="eea-head">
-      <xsl:variable name="xhtml"><head>&head;</head></xsl:variable>
-      <xsl:variable name="head" select="exslt:node-set($xhtml)"/>
-      <xsl:copy-of select="$head/head/*[name()!='base']"/>
+    <!-- EEA HEAD START -->
+    <xsl:variable name="head">
+      <xsl:copy-of select="java:getHEAD()" />
+    </xsl:variable>
+    <xsl:value-of disable-output-escaping="yes"
+      select="$head" />
+    <!-- EEA HEAD END -->
   </xsl:template>
 
   <xsl:template name="eea-footer">
-      &footer;
+    <!-- EEA FOOTER START -->
+    <xsl:variable name="footer">
+      <xsl:copy-of select="java:getFOOTER()" />
+    </xsl:variable>
+    <xsl:value-of disable-output-escaping="yes"
+      select="$footer" />
+    <!-- EEA FOOTER END -->
   </xsl:template>
 
   <xsl:template name="eea-header">
-      &header;
+    <!-- EEA HEADER START -->
+    <xsl:variable name="header">
+      <xsl:copy-of select="java:getHEADER()" />
+    </xsl:variable>
+    <xsl:value-of disable-output-escaping="yes"
+      select="$header" />
+    <!-- EEA HEADER END -->
   </xsl:template>
 
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/eea-layout-api.xsl
+++ b/web/src/main/webapp/xslt/eea-layout-api.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE document [ 
+<!DOCTYPE document [
 <!ENTITY nbsp    "&#160;" >
 <!ENTITY iexcl   "&#161;" >
 <!ENTITY cent    "&#162;" >
@@ -257,10 +257,10 @@
   xmlns:exslt="http://exslt.org/common"
   xmlns:java="java:org.fao.geonet.api.eealayoutapi.EEALayoutManager"
   exclude-result-prefixes="#all">
-  
+
   <xsl:param name="java" />
 
-  <xsl:template name="eea-head">
+  <xsl:template name="eea-head-api">
     <!-- EEA HEAD START -->
     <xsl:variable name="head">
       <xsl:copy-of select="java:getHEAD()" />
@@ -270,7 +270,7 @@
     <!-- EEA HEAD END -->
   </xsl:template>
 
-  <xsl:template name="eea-footer">
+  <xsl:template name="eea-footer-api">
     <!-- EEA FOOTER START -->
     <xsl:variable name="footer">
       <xsl:copy-of select="java:getFOOTER()" />
@@ -280,7 +280,7 @@
     <!-- EEA FOOTER END -->
   </xsl:template>
 
-  <xsl:template name="eea-header">
+  <xsl:template name="eea-header-api">
     <!-- EEA HEADER START -->
     <xsl:variable name="header">
       <xsl:copy-of select="java:getHEADER()" />


### PR DESCRIPTION
Add the possibility to use EEA template API mode and refresh it when required.

In case the API breaks the app (eg. CSS conflicts), catalogue administrator can still access the application with the ```noeeaapi``` URL parameter (http://localhost:8080/geonetwork/srv/eng/catalog.search?noeeaapi) and then turn the API mode off if needed from the admin > settings page.

![image](https://user-images.githubusercontent.com/1701393/43953363-f88f70b0-9c98-11e8-99ff-feb519dbfd2f.png)
